### PR TITLE
Replace \\ with / in template ID because of win32 file systems

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -14,7 +14,7 @@ module.exports.init = function(grunt) {
 
   var concat = function(base, files, callback) {
     grunt.utils.async.concatSeries(files, function(file, next) {
-      var id        = path.relative(base, file);
+      var id        = path.relative(base, file).replace( /\\/g, '/');
       var template  = '\n  $templateCache.put("<%= id %>",\n    "<%= content %>"\n  );\n';
       var cleaned   = grunt.file.read(file).replace(/"/g, '\\"').replace(/\r?\n/g, '" +\n    "');
       var cached    = grunt.template.process(template, {


### PR DESCRIPTION
Refs #3 

@RogueVoo Does `grunt test` pass for you with this?
