### PR TITLE
Add module to available options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,14 @@ module.exports = function(grunt) {
         },
         src: ['test/fixtures/simple.html'],
         dest: 'tmp/simple_prepend.js'
+      },
+      target: {
+        options: {
+          base: 'test/fixtures',
+          module: 'ImAModuleNotATarget'
+        },
+        src: ['test/fixtures/simple.html'],
+        dest: 'tmp/options_module.js'
       }
     }
   });

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ which preloads `$templateCache` to prevent round-trips to the server.
 ```js
 // grunt.js
 grunt.initConfig({
-  ngtemplates:    {
-    myapp:        {
-      options:    {
+  ngtemplates: {
+    build: {
+      options: {
         base:     'src/views',        // $templateCache ID will be relative to this folder
-        prepend:  '/static/assets/'   // (Optional) Prepend path to $templateCache ID
+        prepend:  '/static/assets/',  // (Optional) Prepend path to $templateCache ID
+        module:   'App' // (Optional) The module the templates will be added to, defaults to target if not present ('build' in this case)
       },
       src:        [ 'src/views/**.html' ],
       dest:       'dist/templates.js'
@@ -44,13 +45,10 @@ grunt.initConfig({
 });
 ```
 
-**You should name your sub-target (e.g. `myapp`) after the name of the module the templates will be added to**.
-
-
 This will generate the following at `dist/templates.js`:
 
 ```js
-angular.module('myapp').run(['$templateCache', function($templateCache) {
+angular.module('App').run(['$templateCache', function($templateCache) {
   ...
 }]);
 ```

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
   var compiler = require('./lib/compiler').init(grunt);
 
   grunt.registerMultiTask('ngtemplates', 'Compile AngularJS templates', function() {
-    var id        = this.target;
+    var id        = this.options().module || this.target;
     var files     = grunt.file.expand(this.files[0].src);
     var dest      = path.normalize(this.files[0].dest);
     var done      = this.async();

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -33,6 +33,16 @@ exports.ngtemplates = {
 
     test.equal(expected, actual, 'should prepend $templateCache ID with /prepend/simple.html"');
     test.done();
+  },
+
+  module: function(test) {
+    test.expect(1);
+
+    var actual    = grunt.file.read('tmp/options_module.js');
+    var expected  = grunt.file.read('test/expected/options_module.js');
+
+    test.equal(expected, actual, 'should set the angular module to the provided options value');
+    test.done();
   }
 
 };

--- a/test/expected/options_module.js
+++ b/test/expected/options_module.js
@@ -1,0 +1,8 @@
+angular.module("ImAModuleNotATarget").run(["$templateCache", function($templateCache) {
+
+  $templateCache.put("simple.html",
+    "Howdy there! \\ Your name is \"{{ name }}\"." +
+    ""
+  );
+
+}]);


### PR DESCRIPTION
Hi there,

This commit allows for grunt targets that do not match the angular module name. It's fully backwards compatible, includes tests, and a README update. 

Let me know if you have any concerns or change requests. 

Cheers,

Sid
