### PR TITLE
fix concat & usemin combo

### DIFF
--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -53,7 +53,10 @@ module.exports = function(grunt) {
                 files[key] = Array.isArray(files[key]) ? files[key] : [ files[key] ];
                 files[key].push(dest);
               }
-            } else {
+            } else if (Array.isArray(task)) {
+                task.push(dest);
+            }
+            else {
               grunt.log.error('Could not find src or files in concat target: ' + target);
               done(false);
 


### PR DESCRIPTION
Hi,
I've tried to use ngtempates with usemin and concat option, could not make it work.
That patch fixes case when concat task is just array (and it is for concat generated by usemin)
