### PR TITLE
Fix for 'No module' error

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -24,7 +24,7 @@ module.exports.init = function(grunt) {
   };
 
   var compile = function(id, options, files, callback) {
-    var template = 'angular.module("<%= id %>").run(["$templateCache", function($templateCache) {\n<%= content %>\n}]);\n';
+    var template = 'angular.module("<%= id %>", []).run(["$templateCache", function($templateCache) {\n<%= content %>\n}]);\n';
 
     concat(options, files, function(err, concated) {
       var compiled = process(template, id, concated.join(''));


### PR DESCRIPTION
Fix for 'No module' error by adding empty requirement [] 
in angular.module('_someModuleName_', []) definition
