### PR TITLE
Added support for noConflict coming in 1.1/1.2 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,7 +91,15 @@ module.exports = function(grunt) {
         },
         src: 'test/fixtures/multiple/**/*.html',
         dest: 'tmp/concat_multiple_fixture.js'
-      }
+      },
+      noConflict: {
+        options: {
+          base: 'test/fixtures',
+          noConflict: 'notGlobalAngular'
+        },
+        src: 'test/fixtures/simple.html',
+        dest: 'tmp/options_noConflict_fixture.js'
+      },
     }
   });
 

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -16,13 +16,14 @@ module.exports = function(grunt) {
   var compiler = require('./lib/compiler').init(grunt);
 
   grunt.registerMultiTask('ngtemplates', 'Compile AngularJS templates', function() {
-    var id        = this.options().module || this.target;
-    var files     = grunt.file.expand(this.files[0].src);
-    var dest      = path.normalize(this.files[0].dest);
-    var done      = this.async();
-    var options   = this.options();
+    var id          = this.options().module || this.target;
+    var noConflict  = this.options().noConflict || 'angular';
+    var files       = grunt.file.expand(this.files[0].src);
+    var dest        = path.normalize(this.files[0].dest);
+    var done        = this.async();
+    var options     = this.options();
 
-    compiler.compile(id, options, files, function(err, compiled) {
+    compiler.compile(id, noConflict, options, files, function(err, compiled) {
       if (err) {
         done(false);
       } else {

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -23,21 +23,22 @@ module.exports.init = function(grunt) {
     }, callback);
   };
 
-  var compile = function(id, options, files, callback) {
-    var template = 'angular.module("<%= id %>").run(["$templateCache", function($templateCache) {\n<%= content %>\n}]);\n';
+  var compile = function(id, noConflict, options, files, callback) {
+    var template = '<%= noConflict %>.module("<%= id %>").run(["$templateCache", function($templateCache) {\n<%= content %>\n}]);\n';
 
     concat(options, files, function(err, concated) {
-      var compiled = process(template, id, concated.join(''));
+      var compiled = process(template, id, concated.join(''), noConflict);
 
       callback(false, compiled);
     });
   };
 
-  var process = function(template, id, content) {
+  var process = function(template, id, content, noConflict) {
     return grunt.template.process(template, {
       data: {
-        id:       id,
-        content:  content
+        id:         id,
+        content:    content,
+        noConflict: noConflict
       }
     });
   };

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -45,6 +45,16 @@ exports.ngtemplates = {
     test.done();
   },
 
+  noConflict: function(test) {
+    test.expect(1);
+
+    var actual    = grunt.file.read('tmp/options_noConflict_fixture.js');
+    var expected  = grunt.file.read('test/expected/options_noConflict.js');
+
+    test.equal(expected, actual, 'should reference angular by the noConflict options value');
+    test.done();
+  },
+
   concatSimple: function(test) {
     test.expect(1);
 

--- a/test/expected/options_noConflict.js
+++ b/test/expected/options_noConflict.js
@@ -1,0 +1,7 @@
+notGlobalAngular.module("noConflict").run(["$templateCache", function($templateCache) {
+
+  $templateCache.put("simple.html",
+    "Howdy there! \\ Your name is \"{{ name }}\".\n"
+  );
+
+}]);


### PR DESCRIPTION
Added a noConflict option to specify an alternative reference to `angular`. Here's the noConflict pull request that got merged into 1.1:
https://github.com/angular/angular.js/pull/1535/files
