### PR TITLE
Empty template files cause invalid Javascript

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -37,7 +37,7 @@ module.exports.init = function(grunt) {
     return grunt.template.process(template, {
       data: {
         id:         id,
-        content:    content,
+        content:    content.length ? content : '""',
         noConflict: noConflict
       }
     });


### PR DESCRIPTION
I ran into this issue because of a leftover 0 sized template file in my views directory, causing the generated JS to be invalid.
