### PR TITLE
Added support for use a customized template and some text decorators

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,6 @@
  */
 
 'use strict';
-
 module.exports = function(grunt) {
 
   grunt.initConfig({
@@ -100,6 +99,36 @@ module.exports = function(grunt) {
         src: 'test/fixtures/simple.html',
         dest: 'tmp/options_noConflict_fixture.js'
       },
+      template: {
+        options: {
+          base: 'test/fixtures',
+          baseIdent: 4,
+          template: 'define([],function(){\n'+
+            '  return {\n'+
+            '    loadTemplates: function($templateCache){'+
+            '{{content}}'+
+            '    }\n'+
+            '  };\n'+
+            '});'
+        },
+        src: ['test/fixtures/simple.html'],
+        dest: 'tmp/options_template_fixture.js'
+      },
+      templateMulti: {
+        options: {
+          base: 'test/fixtures',
+          baseIdent: 4,
+          template: 'define([],function(){\n'+
+            '  return {\n'+
+            '    loadTemplates: function($templateCache){'+
+            '{{content}}'+
+            '    }\n'+
+            '  };\n'+
+            '});'
+        },
+        src: ['test/fixtures/multiple/**/*.html'],
+        dest: 'tmp/options_templateMulti_fixture.js'
+      }
     }
   });
 

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -22,8 +22,9 @@ module.exports = function(grunt) {
     var dest        = path.normalize(this.files[0].dest);
     var done        = this.async();
     var options     = this.options();
+    var template    = this.options().template;
 
-    compiler.compile(id, noConflict, options, files, function(err, compiled) {
+    compiler.compile(id, noConflict, options, files, template, function(err, compiled) {
       if (err) {
         done(false);
       } else {

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -15,22 +15,39 @@ module.exports.init = function(grunt) {
   var concat = function(options, files, callback) {
     grunt.util.async.concatSeries(files, function(file, next) {
       var id        = (options.prepend || '') + path.relative(options.base || '.', file).replace( /\\/g, '/');
-      var template  = '\n  $templateCache.put("<%= id %>",\n    <%= content %>\n  );\n';
-      var cleaned   = grunt.file.read(file).split(/^/gm).map(function(line) { return JSON.stringify(line); }).join(' +\n    ');
+      var template  = '\n'+(tab(options))+'$templateCache.put("<%= id %>",\n'+'<%= content %>\n'+(tab(options))+');\n';
+      var cleaned   = grunt.file.read(file).split(/^/gm).map(function(line) { return tab(options,2)+JSON.stringify(line); }).join(' +\n');
       var cached    = process(template, id, cleaned);
 
       next(null, cached);
     }, callback);
   };
 
-  var compile = function(id, noConflict, options, files, callback) {
-    var template = '<%= noConflict %>.module("<%= id %>").run(["$templateCache", function($templateCache) {\n<%= content %>\n}]);\n';
+  var tab = function(options, times){
+    times = times || 1;
+    var str = '';
+    var baseIdent = options.baseIdent || 0;
+    var ident = (options.ident || 2)*times;
 
+    return new Array(baseIdent+ident+1).join(' ');
+  };
+
+  var compile = function(id, noConflict, options, files, template, callback) {
+    if(template){
+      template = parseTemplate(template);
+    }
+    else{
+      template =  '<%= noConflict %>.module("<%= id %>").run(["$templateCache", function($templateCache) {\n<%= content %>\n}]);\n';
+    }
     concat(options, files, function(err, concated) {
       var compiled = process(template, id, concated.join(''), noConflict);
 
       callback(false, compiled);
     });
+  };
+
+  var parseTemplate = function(template){
+    return template.replace(/\{\{(\w+)\}\}/gi, "<%=$1%>");
   };
 
   var process = function(template, id, content, noConflict) {

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -73,6 +73,24 @@ exports.ngtemplates = {
 
     test.equal(expected, actual, 'should create concat target that equals ngtemplate');
     test.done();
+  },
+
+  template: function(test){
+    test.expect(1);
+    var actual    = grunt.file.read('tmp/options_template_fixture.js');
+    var expected  = grunt.file.read('test/expected/options_template.js');
+    
+    test.equal(expected, actual, 'should use the alternative template');
+    test.done();
+  },
+
+  templateMulti: function(test){
+    test.expect(1);
+    var actual    = grunt.file.read('tmp/options_templateMulti_fixture.js');
+    var expected  = grunt.file.read('test/expected/options_templateMulti.js');
+    
+    test.equal(expected, actual, 'should use the alternative template with multiple templates');
+    test.done();
   }
 
 };

--- a/test/expected/options_template.js
+++ b/test/expected/options_template.js
@@ -1,0 +1,9 @@
+define([],function(){
+  return {
+    loadTemplates: function($templateCache){
+      $templateCache.put("simple.html",
+        "Howdy there! \\ Your name is \"{{ name }}\".\n"
+      );
+    }
+  };
+});

--- a/test/expected/options_templateMulti.js
+++ b/test/expected/options_templateMulti.js
@@ -1,0 +1,23 @@
+define([],function(){
+  return {
+    loadTemplates: function($templateCache){
+      $templateCache.put("multiple/one.html",
+        "<h1>One</h1>\n" +
+        "\n" +
+        "<p>I am one.</p>\n" +
+        "\n" +
+        "<script>\n" +
+        "  // Test\n" +
+        "  /* comments */\n" +
+        "  var foo = 'bar';\n" +
+        "</script>\n"
+      );
+
+      $templateCache.put("multiple/two/two.html",
+        "<h2>Two</h2>\n" +
+        "\n" +
+        "<p>We are two.</p>\n"
+      );
+    }
+  };
+});


### PR DESCRIPTION
- ident: Number //the amount of spaces used to ident the code. Default 2 
- baseIdent: Number //the amount of spaces used as base to ident the code. Default 0 
- template: String //the template to create the code. You have to use {{variable}} instead of <%=variable%> to prevent grunt parsing
