### PR TITLE
Fix concat option on windows

### DIFF
--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -48,6 +48,7 @@ module.exports = function(grunt) {
           var concat  = grunt.config('concat') || {};
 
           targets.forEach(function(target) {
+            target = path.normalize(target);
             var task = concat[target];
 
             if (!task) {


### PR DESCRIPTION
Currently getting "unknown concat target" error on windows because the
concat target created by usemin uses the normalized path (with
backslashes on windows).

I needed to normalize the concat target in angular-template before looking
it up so it will work on windows also.
