### PR TITLE
Added onlyFilenames option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,6 +55,14 @@ module.exports = function(grunt) {
         src: ['test/fixtures/multiple/**/*.html'],
         dest: 'tmp/multiple.js'
       },
+      onlyFilenames: {
+        options: {
+          base: 'test/fixtures',
+          onlyFilenames: true
+        },
+        src: ['test/fixtures/multiple/**/*.html'],
+        dest: 'tmp/multiple_only_filenames.js'
+      },
       simple: {
         options: {
           base: 'test/fixtures'

--- a/README.md
+++ b/README.md
@@ -31,23 +31,24 @@ which preloads `$templateCache` to prevent round-trips to the server.
 ```js
 // grunt.js
 grunt.initConfig({
-  ngtemplates:      {
-    myapp:          {
-      options:      {
-        base:       'src/views',        // $templateCache ID will be relative to this folder
-        prepend:    '/static/assets/',  // (Optional) Prepend path to $templateCache ID
-        module:     'App'               // (Optional) The module the templates will be added to
-                                        //            Defaults to grunt target name (e.g. `myapp`)
+  ngtemplates:         {
+    myapp:             {
+      options:         {
+        base:          'src/views',        // $templateCache ID will be relative to this folder
+        prepend:       '/static/assets/',  // (Optional) Prepend path to $templateCache ID
+        onlyFilenames: '/static/assets/',  // (Optional) $templateCache IDs are filenames without full path
+        module:        'App'               // (Optional) The module the templates will be added to
+                                           //            Defaults to grunt target name (e.g. `myapp`)
         // ...or...
-        module:     {
-          name:     'App',              // (Optional) Explicitly define module name
-          define:   true                // (Optional) Define new module (Default: false)
+        module:        {
+          name:        'App',              // (Optional) Explicitly define module name
+          define:      true                // (Optional) Define new module (Default: false)
         },
-        concat:     'dist/js/app.js'    // (Optional) Append to existing `concat` target
-        noConflict: 'otherAngular'      // (Optional) Name of angular.noConflict() app uses
+        concat:        'dist/js/app.js'    // (Optional) Append to existing `concat` target
+        noConflict:    'otherAngular'      // (Optional) Name of angular.noConflict() app uses
       },
-      src:          'src/views/**.html',
-      dest:         'dist/templates.js'
+      src:             'src/views/**.html',
+      dest:            'dist/templates.js'
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-angular-templates",
   "description": "Grunt build task to concatenate & register your AngularJS templates in the $templateCache",
-  "version": "0.3.10",
+  "version": "0.3.11-pre",
   "homepage": "https://github.com/ericclemmons/grunt-angular-templates",
   "author": {
     "name": "Eric Clemmons",

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -14,7 +14,10 @@ module.exports.init = function(grunt) {
 
   var concat = function(options, files, callback) {
     grunt.util.async.concatSeries(files, function(file, next) {
-      var id        = (options.prepend || '') + path.relative(options.base || '.', file).replace( /\\/g, '/');
+      var id        = (options.prepend || '') +
+        (options.onlyFilenames ?
+          path.basename(file) :
+          path.relative(options.base || '.', file).replace( /\\/g, '/'));
       var template  = '\n  $templateCache.put("<%= id %>",\n    <%= content %>\n  );\n';
       var cleaned   = grunt.file.read(file).split(/^/gm).map(function(line) { return JSON.stringify(line); }).join(' +\n    ');
       var cached    = process(template, id, cleaned);

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -25,6 +25,16 @@ exports.ngtemplates = {
     test.done();
   },
 
+  onlyFilenames: function(test) {
+    test.expect(1);
+
+    var actual    = grunt.file.read('tmp/multiple_only_filenames.js');
+    var expected  = grunt.file.read('test/expected/multiple_only_filenames.js');
+
+    test.equal(expected, actual, 'should put templates under ids being only filenames, not full paths');
+    test.done();
+  },
+
   prepend: function(test) {
     test.expect(1);
 

--- a/test/expected/multiple_only_filenames.js
+++ b/test/expected/multiple_only_filenames.js
@@ -1,0 +1,21 @@
+angular.module("onlyFilenames").run(["$templateCache", function($templateCache) {
+
+  $templateCache.put("one.html",
+    "<h1>One</h1>\n" +
+    "\n" +
+    "<p>I am one.</p>\n" +
+    "\n" +
+    "<script>\n" +
+    "  // Test\n" +
+    "  /* comments */\n" +
+    "  var foo = 'bar';\n" +
+    "</script>\n"
+  );
+
+  $templateCache.put("two.html",
+    "<h2>Two</h2>\n" +
+    "\n" +
+    "<p>We are two.</p>\n"
+  );
+
+}]);


### PR DESCRIPTION
Added onlyFilenames option, writing templates under ids being only their filenames, not full paths.

My use case is as follows: my application structure has focus on componentization - files (*.js, *.scss, *.html) are grouped into directories representing single components. These directiories can be further grouped to better reflect application structure. This is only for the reader, components themselves don't depend on this structure.

I don't want to write the full path to templates in directives as it would break the assumption that components can be freely moved between directories (I have another task that adds all scrips from `components/**/*.js` as script tags in HTML so that I don't have to think about it). That's why I need an option to put templates in the `$templateCache` by their file name without the full path. Current task options don't allow such usage.

This pull request adds the `onlyFilenames` option which, when set to `true`, makes the task use filenames as IDs in the `$templateCache` service, optionally prepended by what's inside the `prepend` option. A test is included, as is a README update.
