### PR TITLE
Feat: Allow template name to be configurable.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var path = require('path');
+
 module.exports = function(grunt) {
 
   grunt.initConfig({
@@ -131,6 +133,15 @@ module.exports = function(grunt) {
         src: 'test/fixtures/simple.html',
         dest: 'tmp/noConflict_option_fixture.js'
       },
+      templateConfig: {
+        options: {
+          templateConfig: function (file) {
+            return path.join('foo', file);
+          }
+        },
+        src: ['test/fixtures/simple.html'],
+        dest: 'tmp/template_config.js'
+      }
     }
   });
 

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -14,13 +14,20 @@ module.exports.init = function(grunt) {
 
   var concat = function(options, files, callback) {
     grunt.util.async.concatSeries(files, function(file, next) {
-      var id        = (options.prepend || '') + path.relative(options.base || '.', file).replace( /\\/g, '/');
+      var id        = templateId(options, file);
       var template  = '\n  $templateCache.put("<%= id %>",\n    <%= content %>\n  );\n';
       var cleaned   = grunt.file.read(file).split(/^/gm).map(function(line) { return JSON.stringify(line); }).join(' +\n    ');
       var cached    = process(template, id, cleaned);
 
       next(null, cached);
     }, callback);
+  };
+
+  var templateId = function(options, file) {
+    return (typeof options.templateConfig === 'function'?
+      options.templateConfig(file):
+      (options.prepend || '') + path.relative(options.base || '.', file)
+    ).replace(/\\/g, '/');
   };
 
   var compile = function(id, noConflict, define, options, files, callback) {

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -103,6 +103,17 @@ exports.ngtemplates = {
 
     test.equal(expected, actual, 'should create concat target that equals ngtemplate');
     test.done();
+  },
+
+  templateConfig: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/template_config.js');
+    var expected = grunt.file.read('test/expected/template_config.js');
+
+    test.equal(expected, actual, 'should allow the templateId to be customizable');
+
+    test.done();
   }
 
 };

--- a/test/expected/template_config.js
+++ b/test/expected/template_config.js
@@ -1,0 +1,7 @@
+angular.module("templateConfig").run(["$templateCache", function($templateCache) {
+
+  $templateCache.put("foo/test/fixtures/simple.html",
+    "Howdy there! \\ Your name is \"{{ name }}\".\n"
+  );
+
+}]);


### PR DESCRIPTION
This patch is similar to #33 in that it allows the template name to be configurable. Ex:

```
ngtemplates:    {
  templateConfig: {
    options: {
      templateConfig: function (file) {
        return path.join('foo', file);
      }
    },
    src: ['test/fixtures/simple.html'],
    dest: 'tmp/template_config.js'
  }
}
```

Will prepend all template names with the string `foo/`.

This allows template name configuration to live in the `Gruntfile`. If this config is not set, then the other options (`prepend`, `base`) will be used like before.
