### PR TITLE
Fix html-minifier dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,15 @@
   "scripts": {
     "test": "./node_modules/.bin/grunt"
   },
+  "dependencies": {
+    "html-minifier": "~0.5.2"
+  },
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt-cli": "~0.1.6",
-    "html-minifier": "~0.5.2"
+    "grunt-cli": "~0.1.6"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Current release cannot be used because html-minifier is listed as a devDependency (which doesn't get installed in real-world use).

You'll need to do a new release after this merge, the package is currently unusable.
