### PR TITLE
Updating readme for cwd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ that the template URL is **different** from the file path.
 ngtemplates:  {
   app:        {
     cwd:      'src/app',
-    src:      'src/app/templates/**.html',
+    src:      'templates/**.html',
     dest:     'build/app.templates.js'
   }
 }


### PR DESCRIPTION
When using `cwd` the `src` path should be relative to the path you used in `cwd`.
