### PR TITLE
Split out grunt.config get/set into two discrete calls.

### DIFF
--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -65,7 +65,8 @@ module.exports = function(grunt) {
           options.concat = options.concat.replace(/\//g, '\\');
         }
         
-        var config = grunt.config(['concat', options.concat]);
+        grunt.config(['concat', options.concat]);
+        var config = grunt.config(['concat']);
 
         if (!config) {
           grunt.log.warn('Concat target not found: ' + options.concat.red);


### PR DESCRIPTION
Setting the grunt config is returning null rather than the value that it was set to. This was causing the task to never find the target in which to concat to. 
