### PR TITLE
Basically, the Path module's join assumes you're only working with paths...

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -9,7 +9,7 @@
 'use strict';
 
 var minify  = require('html-minifier').minify;
-var Path    = require('path');
+var Url    = require('url');
 
 /**
  * Angular Template Compiler
@@ -38,9 +38,7 @@ var Compiler = function(grunt, options, cwd) {
    */
   this.cache = function(template, url, prefix) {
   	prefix = prefix || '';
-  	var hasSchemeRegex = /:\/\//g;
-  	url.replace(/\\/g, '/');
-  	var path = hasSchemeRegex.test(prefix) || hasSchemeRegex.test(url) || hasSchemeRegex.test(prefix + url) ? prefix + url : Path.join( prefix, url );
+  	var path = prefix + Url.format( Url.parse( url.replace(/\\/g, '/') ) );
 
     return grunt.template.process(
       "\n  $templateCache.put('<%= path %>',\n    <%= template %>\n  );\n",


### PR DESCRIPTION
..., and as url's are not merely paths when they specify a scheme (https://, http://, etc), this normalization breaks some builds. Allows developers to specify strings that incorporate two forward slashes intentionally as part of the scheme of their template urls (for instance, for hosting those files from a CDN when not pre-cached - and note that the Path module's normalization doesn't take this case into account) by checking whether the involved parts of the url include "://" and if so, simply concatenating them, and using Path's join (which normalizes the resulting url) otherwise.
