### PR TITLE
Make usemin option work without uglify.

### DIFF
--- a/tasks/lib/appender.js
+++ b/tasks/lib/appender.js
@@ -68,9 +68,14 @@ var Appender = function(grunt) {
    */
   this.concatUseminFiles = function(path, file) {
     var config = grunt.config('uglify.generated');
+    var willUglify = !!config;
 
     if (!config) {
-      grunt.log.warn('Usemin has not created ' + 'uglify.generated'.red + ' yet!');
+      config = grunt.config('concat.generated');
+    }
+
+    if (!config) {
+      grunt.log.warn('Usemin has not created ' + 'uglify.generated'.red + ' or ' + 'concat.generated'.red + ' yet!');
 
       return false;
     }
@@ -99,11 +104,11 @@ var Appender = function(grunt) {
       grunt.log.warn('Multiple matches for ' + path.yellow + '.  Using ' + match.dest);
     }
 
-    var uglified = match.src.pop();
+    var target = (willUglify)?match.src.pop():match.dest;
 
     // Finally, modify concat target sourced by matching uglify target
     return this.concatFiles('generated', file, function(files) {
-      return uglified === files.dest;
+      return target === files.dest;
     });
   };
 
@@ -124,3 +129,4 @@ var Appender = function(grunt) {
 };
 
 module.exports = Appender;
+


### PR DESCRIPTION
I'm embedding my angular app inside a .NET MVC app, and want to let MVC's bundling handle the minification,  so I took uglify out of the usemin flow and am just using it for concatenation.

This change to the ngtemplates appender falls back on looking for the concat.generated task and appending its template concatenation to there instead.

I tried to write tests, but couldn't convince the usemin task to build both uglified and non-uglified files.