### PR TITLE
Add slash escaping for usemin target on Windows

### DIFF
--- a/tasks/lib/appender.js
+++ b/tasks/lib/appender.js
@@ -75,6 +75,10 @@ var Appender = function(grunt) {
       return false;
     }
 
+    if (process.platform === 'win32') {
+      path = path.replace(/\//g, '\\');
+    }
+
     // Find uglify destination(s) matching output path
     var matches = grunt.task.normalizeMultiTaskFiles(config)
       .map(function(files) {


### PR DESCRIPTION
Hi,

This is a fix for the problem in issue #70. The workaround of specifying \\ instead of / in the usemin target path works, but we run our grunt build process on Mac and Windows machines, so it would be nice to have one target that works for both platforms. Plus, it looks like the grunt/usemin convention is to use forward slashes everywhere.

I wasn't sure how to write a test for this, since the tests don't seem to work on Windows (on my machine, anyway).

Thanks!
