### PR TITLE
Added minimum version for grunt-usemin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ the template is already loaded without an extra AJAX request!
 
 *This plugin requires [Grunt][1] `~0.4.0`*
 
+*Usemin integration requires [grunt-usemin][5] `~2.0.0`*
+
 Install the plugin:
 
     $ npm install grunt-angular-templates --save-dev


### PR DESCRIPTION
Coming from older (couple months) yeoman generators could cause one's version of usemin to not be compatible (does not work with usemin 1.1.2 or earlier).

Save someone a half hour's worth of work trying to track down the meaning of:
`>> Usemin has not created uglify.generated yet!`

(apologies for the prior wrong direction pull request!)
