### PR TITLE
Fixed: If html file is an underscope (loDash) template, it won't be comp...

### DIFF
--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -14,17 +14,7 @@ var Appender  = require('./lib/appender');
 module.exports = function(grunt) {
 
   var bootstrapper = function(module, script, options) {
-    return grunt.template.process(
-      "<%= angular %>.module('<%= module %>'<%= standalone %>).run(['$templateCache', function($templateCache) {\n<%= script %>\n}]);\n",
-      {
-        data: {
-          'angular':    options.angular,
-          'module':     module,
-          'standalone': options.standalone ? ', []' : '',
-          'script':     script
-        }
-      }
-    );
+    return options.angular+".module('"+module+"'"+(options.standalone ? ', []' : '')+").run(['$templateCache', function($templateCache) {\n"+script+"\n}]);\n";
   };
 
   var ngtemplatesTask = function() {

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -47,15 +47,7 @@ var Compiler = function(grunt, options, cwd) {
     // Append formatted URL
     path += Url.format( Url.parse( url.replace(/\\/g, '/') ) );
 
-    return grunt.template.process(
-      "\n  $templateCache.put('<%= path %>',\n    <%= template %>\n  );\n",
-      {
-        data: {
-          path:     path,
-          template: template
-        }
-      }
-    );
+    return "\n  $templateCache.put('" + path + "',\n    " + template + "\n  );\n";
   };
 
   /**


### PR DESCRIPTION
...iled. Use a plain concation instead 'grunt.template.process'
