### PR TITLE
Fix path matching issue with usemin on Windows

### DIFF
--- a/tasks/lib/appender.js
+++ b/tasks/lib/appender.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var Path = require('path');
+
 /**
  * Utility for modifying other grunt tasks
  * @param {Object} grunt Grunt global object
@@ -81,7 +83,7 @@ var Appender = function(grunt) {
         return files.orig;
       })
       .filter(function(files) {
-        return path === files.dest.substr(-path.length);
+        return Path.normalize(path) === files.dest.substr(-path.length);
       })
     ;
 


### PR DESCRIPTION
When you are working with both Windows and Linux, a common solution must be used for how path are compared with usemin:

```
ngtemplates: {
    dist: {
        options: {
            usemin: 'scripts' + Path.sep + 'scripts.js',
        }
    }
}
```

It would be better instead to normalize the path specified in the build:js section and compare with the file system result.

Note that tests were not updated because they will not run on Windows (I attempted to fix them quickly but I don't have more time to put on this at the moment)
