### PR TITLE
fix(usemin): do not clear generated file if section not found

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,6 +97,14 @@ module.exports = function(grunt) {
         }
       },
 
+      custom_usemin_not_found: {
+        src: ['test/fixtures/one.html', 'test/fixtures/two/**/*.html'],
+        dest: 'tmp/custom_concat_usemin_not_found.js',
+        options: {
+          usemin: 'usemin/not_found.js'
+        }
+      },
+
       html5: {
         src: ['test/fixtures/html5.html'],
         dest: 'tmp/html5.js'

--- a/tasks/lib/appender.js
+++ b/tasks/lib/appender.js
@@ -117,7 +117,7 @@ var Appender = function(grunt) {
    */
   this.save = function(target, files) {
     grunt.config(['concat', target], {
-      files:    files,
+      files:    files || grunt.config(['concat', target, 'files']),
       options:  grunt.config(['concat', target, 'options']) || {}
     });
 


### PR DESCRIPTION
Before this change, configuring a usemin section that does not exist caused the concat/generated/files section to be set to `false`. We now leave it unchanged in case the `appender.save()` is invoked with `false`. I didn't write a test for this, I just added a config with a "not found" section to `grunt` and the fact that the existing `usemin` test works correctly means that it is working...
