### PR TITLE
Typo in ReadMe installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Install the plugin:
 Enable the plugin within your `Gruntfile`:
 
 ```js
-grunt.loadTasks('grunt-angular-templates');
+grunt.loadNpmTasks('grunt-angular-templates');
 ```
 
 


### PR DESCRIPTION
I believe you probably meant 'loadNpmTasks', not 'loadTasks'. I just copy/pasted from those instructions, and it wasn't working. It took me a minute to realize the 'Npm' part was missing.
