### PR TITLE
Update html-minifier dependency to fix some problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "./node_modules/.bin/grunt"
   },
   "dependencies": {
-    "html-minifier": "~0.5.4"
+    "html-minifier": "~0.6.3"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
In my use case, I want to use the collaspeWhitespace option to reduce the size of my templates but html-minifier 0.5.4 has some problems where it is a bit too greedy with collapsing whitespace. For example:
`html
<input type='checkbox' /> Foo
`
is minified to:
`html
<input type='checkbox'>Foo
`

Note the missing whitespace in front of Foo, this whitespace is significant with regards to styling and shouldn't be stripped; 0.6+ fixes this problem.
