### PR TITLE
Output offending template at minification error

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -118,7 +118,7 @@ var Compiler = function(grunt, options, cwd) {
       try {
         source = minify(source, options.htmlmin);
       } catch (err) {
-        grunt.warn(err);
+        grunt.warn(err + '\n\n' + source + '\n\n');
       }
     }
 


### PR DESCRIPTION
If a syntax error is raised while minifying and concating multiple templates, It could be hard to find the offending template. This PR output the offending template along with the error returned by htmlminifier.
