### PR TITLE
added $templateCache config filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ bootstrap: function(module, script) {
 }
 ```
 
+#### filter templates
+
+If you need to exclude some templates form the $templateCache (e.g. for some authentication frameworks, to give them a chance to intercept the HTTP request to the server and forward you to the login page), you can exclude entire paths like this:
+
+```js
+templateCache: {
+  excludes: ['app/secured']
+}
+```
+
 ### concat
 
 > Name of `concat` target to append the compiled template path to.


### PR DESCRIPTION
Hi Eric,

to secure an Angular app, with Passport I wanted to exclude some of the templates from $templateCache.

I have made adopted the compile, to support it. Maybe it's interesting for somebody else as well...

regards,
Andreas
