### PR TITLE
Angular module per each files source

### DIFF
--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -42,7 +42,7 @@ module.exports = function(grunt) {
 
       var compiler  = new Compiler(grunt, options, file.cwd);
       var appender  = new Appender(grunt);
-      var modules   = compiler.modules(file.src);
+      var modules   = compiler.modules(file);
       var compiled  = [];
 
       for (var module in modules) {

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -127,27 +127,30 @@ var Compiler = function(grunt, options, cwd) {
 
   /**
    * Get static or dynamic module name from file.
+   * @param  {Object} files Files source
    * @param  {String} file  File name
    * @return {String}
    */
-  this.module = function(file) {
-    if (typeof options.module === 'function') {
-      return options.module(file, options);
+  this.module = function(files, file) {
+    var module = files.module || options.module;
+
+    if (typeof module === 'function') {
+      return module(file, options);
     }
 
-    return options.module;
+    return module;
   };
 
   /**
    * Group files into individual modules
-   * @param  {Array} files  Files
+   * @param  {Object} files  Files source
    * @return {Object}       Key/Value pair of module + files
    */
   this.modules = function(files) {
     var modules = {};
 
-    files.forEach(function(file) {
-      var module = this.module(file);
+    files.src.forEach(function(file) {
+      var module = this.module(files, file);
 
       if (!modules[module]) {
         modules[module] = [];


### PR DESCRIPTION
E.g.: (two components in their own ng-module and a default module for the rest)

``` js
ngtemplates:
  files: [
    { cwd: 'src/components/',
      src: 'component/*.html', dest: 'build/components/component/component-template.js',
      module: 'component' },
    { cwd: 'src/components/',
      src: 'other-component/*.html', dest: 'build/components/other-component/other-component-template.js',
      module: 'other.component' },
    { cwd: 'src/templates/',
      src: '*.html', dest: 'build/templates/app-templates.js' },
  ]
  options: {
    module: 'app'
  }
```
