### PR TITLE
Skip merging source files to a single destination file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -297,6 +297,7 @@ module.exports = function(grunt) {
         dest: 'tmp/custom_concat_usemin_no_uglify.js',
         options: {
           usemin: 'usemin/all.js'
+        }
       },
 
       // bunch of files at different level in a directory (unmerged in dest)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -297,6 +297,14 @@ module.exports = function(grunt) {
         dest: 'tmp/custom_concat_usemin_no_uglify.js',
         options: {
           usemin: 'usemin/all.js'
+      },
+
+      // bunch of files at different level in a directory (unmerged in dest)
+      unmerged_files: {
+        src: 'test/fixtures/unmerged/**/*.html',
+        dest: 'tmp/unmerged/',
+        options: {
+          merge: false
         }
       }
     }

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -31,7 +31,8 @@ module.exports = function(grunt) {
       url:        function(path) { return path; },
       usemin:     null,
       append:     false,
-      quotes:     'double'
+      quotes:     'double',
+      merge:      true
     });
 
     grunt.verbose.writeflags(options, 'Options');
@@ -50,7 +51,14 @@ module.exports = function(grunt) {
       var compiled  = [];
 
       for (var module in modules) {
-        compiled.push(compiler.compile(module, modules[module]));
+        if (options.merge) {
+          compiled.push(compiler.compile(module, modules[module]));
+        } else {
+          //Compiling each file to the same module
+          for (var j = 0; j < file.src.length; j++) {
+            compiled.push(compiler.compile(module, [file.src[j]]));
+          }
+        }
       }
 
       if (options.append){
@@ -58,8 +66,19 @@ module.exports = function(grunt) {
         grunt.log.writeln('File ' + file.dest.cyan + ' updated.');
       }
       else{
-        grunt.file.write(file.dest, compiled.join('\n'));
-        grunt.log.writeln('File ' + file.dest.cyan + ' created.');
+        if (options.merge) {
+          grunt.file.write(file.dest, compiled.join('\n'));
+          grunt.log.writeln('File ' + file.dest.cyan + ' created.');
+        } else {
+          //Writing compiled file to the same relative location as source, without merging them together 
+          for (var i = 0; i < compiled.length; i++) {
+            var dest = file.dest + file.src[i];
+            //Change extension to js from html/htm
+            dest = dest.replace(/(html|htm)$/i, "js");
+            grunt.file.write(dest, compiled[i]);
+            grunt.log.writeln('File ' + dest.cyan + ' created.');
+          }
+        }
       }
 
 

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -250,6 +250,16 @@ exports.ngtemplates = {
     var expected  = grunt.file.read('test/expected/regexp.js');
 
     test.equal(expected, actual);
+  },
+
+  unmerged_files: function(test) {
+    test.expect(5);
+
+    test.equal(grunt.file.read('tmp/unmerged/test/fixtures/unmerged/undefined.js'), grunt.file.read('test/expected/unmerged_files/undefined.js'));
+    test.equal(grunt.file.read('tmp/unmerged/test/fixtures/unmerged/usemin.js'), grunt.file.read('test/expected/unmerged_files/usemin.js'));
+    test.equal(grunt.file.read('tmp/unmerged/test/fixtures/unmerged/level2/empty.js'), grunt.file.read('test/expected/unmerged_files/empty.js'));
+    test.equal(grunt.file.read('tmp/unmerged/test/fixtures/unmerged/level2/html5.js'), grunt.file.read('test/expected/unmerged_files/html5.js'));
+    test.equal(grunt.file.read('tmp/unmerged/test/fixtures/unmerged/level2/level3/one.js'), grunt.file.read('test/expected/unmerged_files/one.js'));
     test.done();
   }
 

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -250,6 +250,7 @@ exports.ngtemplates = {
     var expected  = grunt.file.read('test/expected/regexp.js');
 
     test.equal(expected, actual);
+    test.done();
   },
 
   unmerged_files: function(test) {

--- a/test/expected/unmerged_files/empty.js
+++ b/test/expected/unmerged_files/empty.js
@@ -1,0 +1,8 @@
+angular.module('unmerged_files').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('test/fixtures/unmerged/level2/empty.html',
+    ""
+  );
+
+}]);

--- a/test/expected/unmerged_files/html5.js
+++ b/test/expected/unmerged_files/html5.js
@@ -1,0 +1,20 @@
+angular.module('unmerged_files').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('test/fixtures/unmerged/level2/html5.html',
+    "<div>\n" +
+    "    <span>\n" +
+    "        Self-closing, sucka!\n" +
+    "        <br>\n" +
+    "        <img src='path/to/img'> Howdy\n" +
+    "</div>\n" +
+    "\n" +
+    "<hr>\n" +
+    "\n" +
+    "<table>\n" +
+    "    <tr>\n" +
+    "        <td>\n" +
+    "            Howdy\n"
+  );
+
+}]);

--- a/test/expected/unmerged_files/one.js
+++ b/test/expected/unmerged_files/one.js
@@ -1,0 +1,16 @@
+angular.module('unmerged_files').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('test/fixtures/unmerged/level2/level3/one.html',
+    "<h1>One</h1>\n" +
+    "\n" +
+    "<p class=\"\">I am one.</p>\n" +
+    "\n" +
+    "<script type=\"text/javascript\">\n" +
+    "  // Test\n" +
+    "  /* comments */\n" +
+    "  var foo = 'bar';\n" +
+    "</script>\n"
+  );
+
+}]);

--- a/test/expected/unmerged_files/undefined.js
+++ b/test/expected/unmerged_files/undefined.js
@@ -1,0 +1,16 @@
+angular.module('unmerged_files').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('test/fixtures/unmerged/undefined.html',
+    "<h1>Undefined</h1>\n" +
+    "\n" +
+    "<p class=\"\">I am undefined.</p>\n" +
+    "\n" +
+    "<script type=\"text/javascript\">\n" +
+    "  // Test\n" +
+    "  /* comments */\n" +
+    "  var foo = 'bar';\n" +
+    "</script>\n"
+  );
+
+}]);

--- a/test/expected/unmerged_files/usemin.js
+++ b/test/expected/unmerged_files/usemin.js
@@ -1,0 +1,37 @@
+angular.module('unmerged_files').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('test/fixtures/unmerged/usemin.html',
+    "<!DOCTYPE html>\n" +
+    "    <head>\n" +
+    "        <link rel=\"stylesheet\" href=\"styles/main.css\">\n" +
+    "        <script src=\"scripts/vendor/modernizr.min.js\"></script>\n" +
+    "    </head>\n" +
+    "    <body>\n" +
+    "\n" +
+    "    <!-- build:js usemin/foo.js -->\n" +
+    "    <script src=\"usemin/foo.js\"></script>\n" +
+    "    <!-- endbuild -->\n" +
+    "\n" +
+    "    <!-- build:js usemin/bar.js -->\n" +
+    "    <script src=\"usemin/bar.js\"></script>\n" +
+    "    <!-- endbuild -->\n" +
+    "\n" +
+    "    <!-- build:js usemin/all.js -->\n" +
+    "    <script src=\"usemin/foo.js\"></script>\n" +
+    "    <script src=\"usemin/bar.js\"></script>\n" +
+    "    <!-- endbuild -->\n" +
+    "\n" +
+    "    <!-- build:js duplicate/usemin/all.js -->\n" +
+    "    <script src=\"usemin/foo.js\"></script>\n" +
+    "    <script src=\"usemin/bar.js\"></script>\n" +
+    "    <!-- endbuild -->\n" +
+    "\n" +
+    "    <!-- build:css usemin/bar.css -->\n" +
+    "    <script src=\"usemin/bar.css\"></script>\n" +
+    "    <!-- endbuild -->\n" +
+    "</body>\n" +
+    "</html>\n"
+  );
+
+}]);

--- a/test/fixtures/unmerged/level2/html5.html
+++ b/test/fixtures/unmerged/level2/html5.html
@@ -1,0 +1,13 @@
+<div>
+    <span>
+        Self-closing, sucka!
+        <br>
+        <img src='path/to/img'> Howdy
+</div>
+
+<hr>
+
+<table>
+    <tr>
+        <td>
+            Howdy

--- a/test/fixtures/unmerged/level2/level3/one.html
+++ b/test/fixtures/unmerged/level2/level3/one.html
@@ -1,0 +1,9 @@
+<h1>One</h1>
+
+<p class="">I am one.</p>
+
+<script type="text/javascript">
+  // Test
+  /* comments */
+  var foo = 'bar';
+</script>

--- a/test/fixtures/unmerged/undefined.html
+++ b/test/fixtures/unmerged/undefined.html
@@ -1,0 +1,9 @@
+<h1>Undefined</h1>
+
+<p class="">I am undefined.</p>
+
+<script type="text/javascript">
+  // Test
+  /* comments */
+  var foo = 'bar';
+</script>

--- a/test/fixtures/unmerged/usemin.html
+++ b/test/fixtures/unmerged/usemin.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+    <head>
+        <link rel="stylesheet" href="styles/main.css">
+        <script src="scripts/vendor/modernizr.min.js"></script>
+    </head>
+    <body>
+
+    <!-- build:js usemin/foo.js -->
+    <script src="usemin/foo.js"></script>
+    <!-- endbuild -->
+
+    <!-- build:js usemin/bar.js -->
+    <script src="usemin/bar.js"></script>
+    <!-- endbuild -->
+
+    <!-- build:js usemin/all.js -->
+    <script src="usemin/foo.js"></script>
+    <script src="usemin/bar.js"></script>
+    <!-- endbuild -->
+
+    <!-- build:js duplicate/usemin/all.js -->
+    <script src="usemin/foo.js"></script>
+    <script src="usemin/bar.js"></script>
+    <!-- endbuild -->
+
+    <!-- build:css usemin/bar.css -->
+    <script src="usemin/bar.css"></script>
+    <!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
Convert html templates to angular template cache without merging the output together to a single dest file. Output files respect the original folder structure and name of source src files. This behavior is turned off by default and could be turned on by setting merge: true in the options.