### PR TITLE
added templateWrap callback option and strictMode boolean option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ bootstrap: function(module, script) {
 }
 ```
 
+### templateWrap
+
+> Callback to modify the way each template is registered
+
+By default, the templateWrap wraps each template with
+
+```js
+$templateCache.put(path, template);
+```
+
+If you want to create your own wrapper so you can use a different caching service, or wrap them in a different manner:
+
+```js
+templateWrap: function(path, script) {
+  return "$localStorage.put('" + path + "', " + template + ");"
+}
+```
+
 ### concat
 
 > Name of `concat` target to append the compiled template path to.
@@ -173,6 +191,10 @@ ensures that URLs load via both AJAX and `$templateCache`.
 
 This should be the output path of the compiled JS indicated in your HTML,
 such as `path/to/output.js` shown here.
+
+### strictMode
+
+> Boolean indicated if 'use strict' should be attached to the top of the generated templates file.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # grunt-angular-templates
 
+## This is a fork of the original [grunt-angular-templates](https://github.com/ericclemmons/grunt-angular-templates), to support the features added (but not yet merged) in this pull request: [added templateWrap callback option and strictMode boolean option](https://github.com/ericclemmons/grunt-angular-templates/pull/119)
+
+### All credits to the original project collaborators.
+
 [![Build Status](https://travis-ci.org/ericclemmons/grunt-angular-templates.svg)](https://travis-ci.org/ericclemmons/grunt-angular-templates)
 [![Dependencies](https://david-dm.org/ericclemmons/grunt-angular-templates.svg)](https://david-dm.org/ericclemmons/grunt-angular-templates)
 [![devDependencies](https://david-dm.org/ericclemmons/grunt-angular-templates/dev-status.svg)](https://david-dm.org/ericclemmons/grunt-angular-templates#info=devDependencies&view=table)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $templateCache.put(path, template);
 If you want to create your own wrapper so you can use a different caching service, or wrap them in a different manner:
 
 ```js
-templateWrap: function(path, script) {
+templateWrap: function(path, script, index, files) {
   return "$localStorage.put('" + path + "', " + template + ");"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "grunt-angular-templates",
+  "name": "grunt-angular-templates-taylorcode",
   "description": "Grunt build task to concatenate & register your AngularJS templates in the $templateCache",
-  "version": "0.5.7",
-  "homepage": "https://github.com/ericclemmons/grunt-angular-templates",
+  "version": "0.5.7-m",
+  "homepage": "https://github.com/taylorcode/grunt-angular-templates",
   "author": {
-    "name": "Eric Clemmons",
-    "email": "eric@smarterspam.com"
+    "name": "Taylor McIntyre",
+    "email": "taylorsmcintyre@gmail.com"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/ericclemmons/grunt-angular-templates.git"
+    "url": "git://github.com/taylorcode/grunt-angular-templates.git"
   },
   "bugs": {
-    "url": "https://github.com/ericclemmons/grunt-angular-templates/issues"
+    "url": "https://github.com/taylorcode/grunt-angular-templates/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/ericclemmons/grunt-angular-templates/blob/master/LICENSE-MIT"
+      "url": "https://github.com/taylorcode/grunt-angular-templates/blob/master/LICENSE-MIT"
     }
   ],
   "main": "Gruntfile.js",

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -18,6 +18,10 @@ module.exports = function(grunt) {
     return options.angular+".module('"+module+"'"+(options.standalone ? ', []' : '')+").run(['$templateCache', function($templateCache) {\n"+script+"\n}]);\n";
   };
 
+  var templateWrapper = function(path, template) {
+    return "\n  $templateCache.put('" + path + "',\n    " + template + "\n  );\n";
+  }
+
   var ngtemplatesTask = function() {
     var options = this.options({
       angular:    'angular',
@@ -28,6 +32,8 @@ module.exports = function(grunt) {
       prefix:     '',
       source:     function(source) { return source; },
       standalone: false,
+      strictMode: true,
+      templateWrap: templateWrapper,
       url:        function(path) { return path; },
       usemin:     null,
       append:     false

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
 
   var templateWrapper = function(path, template) {
     return "\n  $templateCache.put('" + path + "',\n    " + template + "\n  );\n";
-  }
+  };
 
   var ngtemplatesTask = function() {
     var options = this.options({

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -34,9 +34,10 @@ var Compiler = function(grunt, options, cwd) {
    * Wrap HTML template in what is returned from `options.templateWrap`
    * @param  {String} template  Multiline HTML template string
    * @param  {String} url       URL to act as template ID
+   * @param 
    * @return {String}           Template wrapped using the `options.templateWrap` function
    */
-  this.cache = function(template, url, prefix) {
+  this.cache = function(template, url, prefix, index, files) {
     var path = prefix;
 
     // Force trailing slash
@@ -47,7 +48,7 @@ var Compiler = function(grunt, options, cwd) {
     // Append formatted URL
     path += Url.format( Url.parse( url.replace(/\\/g, '/') ) );
 
-    return options.templateWrap(path, template);
+    return options.templateWrap(path, template, index, files);
   };
 
   /**
@@ -80,7 +81,7 @@ var Compiler = function(grunt, options, cwd) {
       }.bind(this))
       .map(this.stringify)
       .map(function(string, i) {
-        return this.cache(string, this.url(files[i]), options.prefix);
+        return this.cache(string, this.url(files[i]), options.prefix, i, files);
       }.bind(this))
       .map(grunt.util.normalizelf)
       .join(grunt.util.linefeed)

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -31,10 +31,10 @@ var Compiler = function(grunt, options, cwd) {
   };
 
   /**
-   * Wrap HTML template in `$templateCache.put(...)`
+   * Wrap HTML template in what is returned from `options.templateWrap`
    * @param  {String} template  Multiline HTML template string
    * @param  {String} url       URL to act as template ID
-   * @return {String}           Template wrapped in `$templateCache.put(...)`
+   * @return {String}           Template wrapped using the `options.templateWrap` function
    */
   this.cache = function(template, url, prefix) {
     var path = prefix;
@@ -47,7 +47,7 @@ var Compiler = function(grunt, options, cwd) {
     // Append formatted URL
     path += Url.format( Url.parse( url.replace(/\\/g, '/') ) );
 
-    return "\n  $templateCache.put('" + path + "',\n    " + template + "\n  );\n";
+    return options.templateWrap(path, template);
   };
 
   /**
@@ -66,7 +66,11 @@ var Compiler = function(grunt, options, cwd) {
       return true;
     });
 
-    var script = "  'use strict';" + grunt.util.linefeed;
+    var script = grunt.util.linefeed;
+
+    if(options.strictMode) {
+      script = "  'use strict';" + script;
+    }
 
     script += paths
       .map(this.load)


### PR DESCRIPTION
I think that it is useful if the developer can decide how the templates are registered. This allows them to use a different caching service, or even generate a json file (for example) with the templates instead of a js file.
