### PR TITLE
Use '\n' to join the template cache entries regardless of platform

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -78,8 +78,7 @@ var Compiler = function(grunt, options, cwd) {
       .map(function(string, i) {
         return this.cache(string, this.url(files[i]), options.prefix);
       }.bind(this))
-      .map(grunt.util.normalizelf)
-      .join(grunt.util.linefeed)
+      .join('\n')
     ;
 
     return this.bootstrap(module, script);


### PR DESCRIPTION
Also leaves the template cache contents untouched, rather than using normalizelf().

This will ensure that developers using the same repo on different OSes will have identical grunt build output, avoiding constant churn when the built files are committed to the repository.

I've used '\n' for the joins since the rest of grunt-angular-templates uses it, as do other grunt plugins like grunt-contrib-uglify and grunt-usemin.

Fixes #125.

@ericclemmons, could you take a look? :-)