### PR TITLE
Added verbose logging for minify

### DIFF
--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -116,6 +116,7 @@ var Compiler = function(grunt, options, cwd) {
   this.minify = function(source) {
     if (options.htmlmin && Object.keys(options.htmlmin).length) {
       try {
+        grunt.verbose.writeln('Minifying file: ' +source);
         source = minify(source, options.htmlmin);
       } catch (err) {
         grunt.warn(err + '\n\n' + source + '\n\n');


### PR DESCRIPTION
There are a few problems with the html-minfier package.
For instance: https://github.com/ericclemmons/grunt-angular-templates/issues/135

While that issue whould be fixed there, it is hard to get it fixed (if possible)
So i added a verbose logging so that we at leasts know which template is causing the issue...
Otherwise you could be searching for a while :)