### PR TITLE
Adds an option to use single quotes instead of double for quote wrapping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -246,6 +246,14 @@ module.exports = function(grunt) {
       undefined_file: {
         src: 'test/fixtures/undefined.html',
         dest: 'tmp/undefined_file.js'
+      },
+
+      single_quotes: {
+        src: 'test/fixtures/one.html',
+        dest: 'tmp/single_quotes.js',
+        options: {
+          quotes: 'single'
+        }
       }
     }
   });

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ ensures that URLs load via both AJAX and `$templateCache`.
 This should be the output path of the compiled JS indicated in your HTML,
 such as `path/to/output.js` shown here.
 
+### quotes
+
+> Use single or double quotes to wrap the template strings
+
+Defaults to 'double', other option is 'single'
+
 ## Usage
 
 

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -30,7 +30,8 @@ module.exports = function(grunt) {
       standalone: false,
       url:        function(path) { return path; },
       usemin:     null,
-      append:     false
+      append:     false,
+      quotes:     'double'
     });
 
     grunt.verbose.writeflags(options, 'Options');
@@ -57,10 +58,10 @@ module.exports = function(grunt) {
         grunt.log.writeln('File ' + file.dest.cyan + ' updated.');
       }
       else{
-        grunt.file.write(file.dest, compiled.join('\n'));  
+        grunt.file.write(file.dest, compiled.join('\n'));
         grunt.log.writeln('File ' + file.dest.cyan + ' created.');
       }
-      
+
 
       if (options.usemin) {
         if (appender.save('generated', appender.concatUseminFiles(options.usemin, file))) {

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -185,7 +185,13 @@ var Compiler = function(grunt, options, cwd, expanded) {
    */
   this.stringify = function(source) {
     return source.split(/^/gm).map(function(line) {
-      return JSON.stringify(line);
+      var quote = options.quotes === 'single' ? '\'' : '"';
+
+      line = line.replace(/\n/g, '\\n');
+      var quoteRegExp = new RegExp(quote, 'g');
+      line = line.replace(quoteRegExp, '\\' + quote);
+
+      return quote + line + quote;
     }).join(' +\n    ') || '""';
   };
 

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -211,4 +211,14 @@ exports.ngtemplates = {
     test.done();
   },
 
+  single_quote: function(test) {
+    test.expect(1);
+
+    var actual    = grunt.file.read('tmp/single_quotes.js');
+    var expected  = grunt.file.read('test/expected/single_quotes.js');
+
+    test.equal(expected, actual);
+    test.done();
+  }
+
 };

--- a/test/expected/single_quotes.js
+++ b/test/expected/single_quotes.js
@@ -1,0 +1,16 @@
+angular.module('single_quotes').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('test/fixtures/one.html',
+    '<h1>One</h1>\n' +
+    '\n' +
+    '<p class="">I am one.</p>\n' +
+    '\n' +
+    '<script type="text/javascript">\n' +
+    '  // Test\n' +
+    '  /* comments */\n' +
+    '  var foo = \'bar\';\n' +
+    '</script>\n'
+  );
+
+}]);


### PR DESCRIPTION
- We are now doing manual quote wrapping instead of relying on JSON.stringify for greater flexibility

Resolves https://github.com/ericclemmons/grunt-angular-templates/issues/111