### PR TITLE
Improved unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - 0.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 0.10
+  - 0.12
+  - 4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ language: node_js
 node_js:
   - 0.12
   - 4.2
+cache:
+  directories:
+    - node_modules

--- a/package.json
+++ b/package.json
@@ -28,19 +28,19 @@
     "test": "./node_modules/.bin/grunt"
   },
   "dependencies": {
-    "html-minifier": "~0.6.3"
+    "html-minifier": "~1.1.1"
   },
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-cli": "~0.1.6",
-    "grunt-contrib-cssmin": "~0.7.0",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-jshint": "~0.7.2",
-    "grunt-contrib-nodeunit": "~0.2.2",
-    "grunt-contrib-uglify": "~0.2.7",
-    "grunt-usemin": "~2.0.2",
-    "grunt-contrib-copy": "~0.4.1"
+    "grunt-contrib-cssmin": "~0.14.0",
+    "grunt-contrib-clean": "~0.7.0",
+    "grunt-contrib-concat": "~0.5.1",
+    "grunt-contrib-jshint": "~0.12.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt-contrib-uglify": "~0.11.0",
+    "grunt-usemin": "~3.1.1",
+    "grunt-contrib-copy": "~0.8.2"
   },
   "keywords": [
     "gruntplugin",

--- a/test/expected/usemin.html
+++ b/test/expected/usemin.html
@@ -13,6 +13,6 @@
 
     <script src="duplicate/usemin/all.js"></script>
 
-    <link rel="stylesheet" href="usemin/bar.css"/>
+    <link rel="stylesheet" href="usemin/bar.css">
 </body>
 </html>


### PR DESCRIPTION
@ericclemmons @underscorebrody, i noticed that the dev dependencies where really outdated.

i took care of retesting the new stables and to update the only one test that required a change in order to be aligned to latest usemin.

in addition i've applied various improvements:
- unitetests have been switched to travis container based infrastructure (that would allow a minor speed up of builds)
- npm packages are now subject to travis caching e (that would allow a minor speed up of builds and less networking overhead for travis)
- tests are now performed also on on node 4.2 (that is now the LTS and so the most important version to test against)