### PR TITLE
Correctly escape slashes in regular expressions (or really anywhere)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -259,6 +259,11 @@ module.exports = function(grunt) {
       linebreak: {
         src: 'test/fixtures/linebreak.html',
         dest: 'tmp/linebreak.js',
+      },
+
+      regexp: {
+        src: 'test/fixtures/regexp.html',
+        dest: 'tmp/regexp.js'
       }
     }
   });

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -187,6 +187,7 @@ var Compiler = function(grunt, options, cwd, expanded) {
     return source.split(/^/gm).map(function(line) {
       var quote = options.quotes === 'single' ? '\'' : '"';
 
+      line = line.replace(/\\/g, '\\\\');
       line = line.replace(/\n/g, '\\n');
       line = line.replace(/\r/g, '\\r');
       var quoteRegExp = new RegExp(quote, 'g');

--- a/test/angular-templates_test.js
+++ b/test/angular-templates_test.js
@@ -229,6 +229,16 @@ exports.ngtemplates = {
 
     test.equal(expected, actual);
     test.done();
+  },
+
+  regexp: function(test) {
+    test.expect(1);
+
+    var actual    = grunt.file.read('tmp/regexp.js');
+    var expected  = grunt.file.read('test/expected/regexp.js');
+
+    test.equal(expected, actual);
+    test.done();
   }
   
 };

--- a/test/expected/regexp.js
+++ b/test/expected/regexp.js
@@ -1,0 +1,13 @@
+angular.module('regexp').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('test/fixtures/regexp.html',
+    "<h1>Regexp</h1>\n" +
+    "\n" +
+    "<script type=\"text/javascript\">\n" +
+    "  var reg = new RegExp(/^(((\\+[1-9][0-9])|(00[1-9][0-9]))[0-9]{7,11})|((((01|02|03|04|05|07|08)[0-9])|(06[1-9]))[0-9]{7})$/)\n" +
+    "  var reg2 = new RegExp(/^\\+-\\\\--\\|)$/)\n" +
+    "</script>\n"
+  );
+
+}]);

--- a/test/fixtures/regexp.html
+++ b/test/fixtures/regexp.html
@@ -1,0 +1,6 @@
+<h1>Regexp</h1>
+
+<script type="text/javascript">
+  var reg = new RegExp(/^(((\+[1-9][0-9])|(00[1-9][0-9]))[0-9]{7,11})|((((01|02|03|04|05|07|08)[0-9])|(06[1-9]))[0-9]{7})$/)
+  var reg2 = new RegExp(/^\+-\\--\|)$/)
+</script>


### PR DESCRIPTION
- Add a test to cover this scenario

Fixes https://github.com/ericclemmons/grunt-angular-templates/issues/145