### PR TITLE
throw on error of htmlmin error for grunt, so a build fails, now it is silent 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+grunt-angular-templates.iml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,16 +141,16 @@ module.exports = function(grunt) {
         src: ['test/fixtures/one.html', 'test/fixtures/two/**/*.html'],
         dest: 'tmp/custom_htmlmin.js',
         options: {
-          htmlmin: {
-            collapseBooleanAttributes:      true,
-            collapseWhitespace:             true,
-            removeAttributeQuotes:          true,
-            removeComments:                 true,
-            removeEmptyAttributes:          true,
-            removeRedundantAttributes:      true,
-            removeScriptTypeAttributes:     true,
-            removeStyleLinkTypeAttributes:  true
-          }
+            htmlmin: {
+                collapseBooleanAttributes: true,
+                collapseWhitespace: true,
+                removeAttributeQuotes: true,
+                removeComments: true,
+                removeEmptyAttributes: true,
+                removeRedundantAttributes: true,
+                removeScriptTypeAttributes: true,
+                removeStyleLinkTypeAttributes: true
+            }
         }
       },
 
@@ -307,7 +307,30 @@ module.exports = function(grunt) {
         options: {
           merge: false
         }
-      }
+      },
+
+
+        /*
+      throwsOnErrorForHtmlmin: {
+        options: {
+          htmlminThrowOnError: true,
+          htmlmin: {
+              collapseBooleanAttributes:      true,
+              collapseWhitespace:             true,
+              removeAttributeQuotes:          true,
+              removeComments:                 true,
+              removeEmptyAttributes:          true,
+              removeRedundantAttributes:      true,
+              removeScriptTypeAttributes:     true,
+              removeStyleLinkTypeAttributes:  true
+          }
+        },
+        src: ['test/fixtures/htmlmin-throw-on-error.html'],
+        dest: 'tmp/htmlmin-throw-on-error.js'
+      },
+
+      */
+
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -310,7 +310,7 @@ module.exports = function(grunt) {
       },
 
 
-        /*
+      /*
       throwsOnErrorForHtmlmin: {
         options: {
           htmlminThrowOnError: true,
@@ -328,7 +328,6 @@ module.exports = function(grunt) {
         src: ['test/fixtures/htmlmin-throw-on-error.html'],
         dest: 'tmp/htmlmin-throw-on-error.js'
       },
-
       */
 
     }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ I recommend using the following settings for production:
 htmlmin: {
   collapseBooleanAttributes:      true,
   collapseWhitespace:             true,
+  keepClosingSlash:               true, // Only if you are using SVG in HTML
   removeAttributeQuotes:          true,
   removeComments:                 true, // Only if you don't use comment directives!
   removeEmptyAttributes:          true,
@@ -113,7 +114,13 @@ htmlmin: {
   removeStyleLinkTypeAttributes:  true
 }
 ```
-If you are using SVG, please make sure you set ```keepClosingSlash:true```
+
+
+###htmlminThrowOnError
+Default: ```false```
+
+> If you set it to ```true```, it will throw an error. It is good for a build.  
+
 
 ### module
 

--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -32,8 +32,10 @@ module.exports = function(grunt) {
       usemin:     null,
       append:     false,
       quotes:     'double',
-      merge:      true
+      merge:      true,
+      htmlminThrowOnError: false,
     });
+
 
     grunt.verbose.writeflags(options, 'Options');
 

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -125,6 +125,9 @@ var Compiler = function(grunt, options, cwd, expanded) {
         source = minify(source, options.htmlmin);
       } catch (err) {
         grunt.log.error(err + '\n\n' + source + '\n\n');
+        if (options.htmlminThrowOnError) {
+          throw err;
+        }
       }
     }
 

--- a/test/fixtures/htmlmin-throw-on-error.html
+++ b/test/fixtures/htmlmin-throw-on-error.html
@@ -1,0 +1,2 @@
+this shows an error
+<button


### PR DESCRIPTION
I added an option to throw on error of htmlmin error for grunt, so a build fails, now it is silent 