### PR TITLE
Improvements

### DIFF
--- a/tasks/angular-templates.js
+++ b/tasks/angular-templates.js
@@ -68,15 +68,15 @@ module.exports = function(grunt) {
       else{
         if (options.merge) {
           grunt.file.write(file.dest, compiled.join('\n'));
-          grunt.log.writeln('File ' + file.dest.cyan + ' created.');
+          // grunt.log.writeln('File ' + file.dest.cyan + ' created.');
         } else {
-          //Writing compiled file to the same relative location as source, without merging them together 
+          //Writing compiled file to the same relative location as source, without merging them together
           for (var i = 0; i < compiled.length; i++) {
             var dest = file.dest + file.src[i];
             //Change extension to js from html/htm
             dest = dest.replace(/(html|htm)$/i, "js");
             grunt.file.write(dest, compiled[i]);
-            grunt.log.writeln('File ' + dest.cyan + ' created.');
+            // grunt.log.writeln('File ' + dest.cyan + ' created.');
           }
         }
       }

--- a/tasks/lib/compiler.js
+++ b/tasks/lib/compiler.js
@@ -124,7 +124,8 @@ var Compiler = function(grunt, options, cwd, expanded) {
         grunt.verbose.writeln('Minifying file: ' +source);
         source = minify(source, options.htmlmin);
       } catch (err) {
-        grunt.log.error(err + '\n\n' + source + '\n\n');
+        grunt.log.error(err + '\n\n' + source.slice(0,150) + '... \n\n');
+        process.exit(3);
       }
     }
 


### PR DESCRIPTION
I am running this task in my Gruntfile and sometimes I have html parse errors I wouldn't like to miss.
For this reason I think it's good that we add a process.exit(3) when the parser comes across an error.

Also, displaying the whole template can be too verbose (if the file is big). I believe that displaying few lines is enough to know the issue.