### PR TITLE
Update html-minifier dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "./node_modules/.bin/grunt"
   },
   "dependencies": {
-    "html-minifier": "~2.1.2"
+    "html-minifier": "~4.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
your current required html-minifier version relies on an insecure version of clean-css, as per WS-2019-0017 https://github.com/jakubpawlowicz/clean-css/commit/2929bafbf8cdf7dccb24e0949c70833764fa87e3